### PR TITLE
Resolved Module enabling issue for Magento 2.3 and currency symbol made upper case as required by fatzebra

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -107,7 +107,7 @@ class Payment extends \Magento\Payment\Model\Method\Cc
 
         $requestData = [
             'amount'        => $amount,
-            'currency'      => strtolower($order->getBaseCurrencyCode()),
+            'currency'      => $order->getBaseCurrencyCode(), // Removed strtolower to get currency in upper case
             'description'   => sprintf('#%s, %s', $order->getIncrementId(), $order->getCustomerEmail()),
             'card'          => [
                 'number'            => $payment->getCcNumber(),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ PMNTS Magento 2 Module
 
 Overview
 --------
-The PMNTS Magento 2 module provides a simple integration method for Magento 2.0 with the Fat Zebra, Cloud Payments and PMNTS gateway services. This module includes support for the following functionality:
+The PMNTS Magento 2 module provides a simple integration method for Magento 2.x with the Fat Zebra, Cloud Payments and PMNTS gateway services. This module includes support for the following functionality:
 
 * Standard payments through the Gateway API
 * IFRAME card details capture for de-scoping of PCI requirements

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,13 @@
     "require": {
     },
     "type": "magento2-module",
-    "version": "dev-master"
+    "version": "dev-master",
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "PMNTS\\Gateway\\": ""
+        }
+    }
 }


### PR DESCRIPTION
Resolved issue of "module PMNTS_Gateway not found" when tried to enable it by using following command for magento 2.3 community.
`php bin/magento module:enable PMNTS_Gateway --clear-static-content`
Hence changes were made to make the plugin compatible with Magento2.3. Updated README.md and composer.json with magento 2.3 compatible module name for autoload key. 

To resolve the currency issue: <When order was placed to process the payment an error occurred that current is in aud and eligible currencies are AUD etc>

> > Capture method in Model Payment.php was updated to remove strtolower method to send currency in uppercase as required by Fatzebra e.g. AUD