### PR TITLE
Also remove Encryptor parameter from subclasses now that it is no longer needed

### DIFF
--- a/Gateway/CaptureCommand.php
+++ b/Gateway/CaptureCommand.php
@@ -24,9 +24,6 @@ class CaptureCommand extends AbstractCommand
     /** @var \Magento\Framework\Serialize\Serializer\Json */
     private $json;
 
-    /** @var \Magento\Framework\Encryption\EncryptorInterface */
-    private $encryptor;
-
     /** @var \Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory */
     private $paymentExtensionInterfaceFactory;
 
@@ -43,12 +40,10 @@ class CaptureCommand extends AbstractCommand
      * @param \PMNTS\Gateway\Helper\Data $pmntsHelper
      * @param \PMNTS\Gateway\Model\GatewayFactory $gatewayFactory
      * @param \Psr\Log\LoggerInterface $logger
-     * @param \Magento\Framework\Encryption\EncryptorInterface $crypt
      * @param \Magento\Vault\Model\PaymentTokenFactory $paymentTokenFactory
      * @param \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository
      * @param \Magento\Vault\Api\PaymentTokenRepositoryInterface $paymentTokenRepository
      * @param \Magento\Framework\Serialize\Serializer\Json $json
-     * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
      * @param \Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory $paymentExtensionInterfaceFactory
      */
     public function __construct(
@@ -56,20 +51,17 @@ class CaptureCommand extends AbstractCommand
         \PMNTS\Gateway\Helper\Data $pmntsHelper,
         \PMNTS\Gateway\Model\GatewayFactory $gatewayFactory,
         \Psr\Log\LoggerInterface $logger,
-        \Magento\Framework\Encryption\EncryptorInterface $crypt,
         \Magento\Vault\Model\PaymentTokenFactory $paymentTokenFactory,
         \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
         \Magento\Vault\Api\PaymentTokenRepositoryInterface $paymentTokenRepository,
         \Magento\Framework\Serialize\Serializer\Json $json,
-        \Magento\Framework\Encryption\EncryptorInterface $encryptor,
         \Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory $paymentExtensionInterfaceFactory
     ) {
-        parent::__construct($scopeConfig, $pmntsHelper, $gatewayFactory, $logger, $crypt);
+        parent::__construct($scopeConfig, $pmntsHelper, $gatewayFactory, $logger);
         $this->paymentTokenFactory = $paymentTokenFactory;
         $this->customerRepository = $customerRepository;
         $this->paymentTokenRepository = $paymentTokenRepository;
         $this->json = $json;
-        $this->encryptor = $encryptor;
         $this->paymentExtensionInterfaceFactory = $paymentExtensionInterfaceFactory;
     }
 

--- a/Gateway/VaultCaptureCommand.php
+++ b/Gateway/VaultCaptureCommand.php
@@ -25,7 +25,6 @@ class VaultCaptureCommand extends AbstractCommand
      * @param \PMNTS\Gateway\Helper\Data $pmntsHelper
      * @param \PMNTS\Gateway\Model\GatewayFactory $gatewayFactory
      * @param LoggerInterface $logger
-     * @param \Magento\Framework\Encryption\EncryptorInterface $crypt
      * @param \Magento\Vault\Api\PaymentTokenManagementInterface $tokenManagement
      */
     public function __construct(
@@ -33,10 +32,9 @@ class VaultCaptureCommand extends AbstractCommand
         \PMNTS\Gateway\Helper\Data $pmntsHelper,
         \PMNTS\Gateway\Model\GatewayFactory $gatewayFactory,
         \Psr\Log\LoggerInterface $logger,
-        \Magento\Framework\Encryption\EncryptorInterface $crypt,
         \Magento\Vault\Api\PaymentTokenManagementInterface $tokenManagement
     ) {
-        parent::__construct($scopeConfig, $pmntsHelper, $gatewayFactory, $logger, $crypt);
+        parent::__construct($scopeConfig, $pmntsHelper, $gatewayFactory, $logger);
         $this->tokenManagement = $tokenManagement;
     }
 


### PR DESCRIPTION
Apologies - my latest commits (merged in https://github.com/PMNTS/magento2-pmnts/pull/6/files) which refactored the config decryption missed the removal of that encryptor parameter from the sub-classes. Since this is no longer expected by the parent class, it should also be removed from CaptureCommand and VaultCaptureCommand as well.

This is quite a critical update since DI compilation will fail loudly with the current master branch.